### PR TITLE
feat: get returnTo app signal from the wallet via relay instead

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,12 +25,6 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter android:autoVerify="true">
-                <data android:scheme="passkeys" />
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-            </intent-filter>
         </activity>
     </application>
 

--- a/android/app/src/main/java/com/passkeysandroid/MainActivity.kt
+++ b/android/app/src/main/java/com/passkeysandroid/MainActivity.kt
@@ -1,7 +1,7 @@
-// MainActivity.kt
 package com.passkeysandroid
 
 import android.app.Activity
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -9,12 +9,12 @@ import android.os.Bundle
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import android.webkit.WebSettings
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsIntent
 
 class MainActivity : AppCompatActivity() {
 
+    private var closeCustomTabIntent: PendingIntent? = null
     private lateinit var webView: WebView
     private val CUSTOM_TAB_REQUEST_CODE = 100
 
@@ -25,21 +25,29 @@ class MainActivity : AppCompatActivity() {
         webView = findViewById(R.id.webView)
         setupWebView(webView)
 
-        webView.loadUrl("https://dev.passkeys.foundation/playground?relay&returnTo=passkeys%3A%2F%2F%0A")
-    }
-
-    override fun onNewIntent(intent: Intent?) {
-        super.onNewIntent(intent)
-        intent?.data?.let { uri ->
-            if (uri.scheme == "passkeys") {
-                webView.reload()
+        webView.loadUrl("https://dev.passkeys.foundation/playground?relay")
+        webView.evaluateJavascript("""
+            if (!window.uiControl) {
+                window.uiControl = {};
             }
-        }
+            window.uiControl.closeSigner = function() {
+                AndroidBridge.closeSigner();
+            };
+        """) { }
+
+        this.closeCustomTabIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
     }
 
     private fun setupWebView(webView: WebView) {
         webView.settings.javaScriptEnabled = true
         webView.settings.domStorageEnabled = true
+        webView.addJavascriptInterface(JavaScriptBridge(this), "AndroidBridge")
+
         webView.webViewClient = object : WebViewClient() {
             override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
                 openInCustomTab(this@MainActivity, request.url.toString())
@@ -63,6 +71,21 @@ class MainActivity : AppCompatActivity() {
             if (resultCode == Activity.RESULT_CANCELED) {
                 webView.reload()
             }
+        }
+    }
+
+    fun onCloseSigner() {
+        closeCustomTabIntent?.send()
+    }
+}
+
+// JavaScript Bridge class for communication
+class JavaScriptBridge(private val activity: MainActivity) {
+
+    @android.webkit.JavascriptInterface
+    fun closeSigner() {
+        activity.runOnUiThread {
+            activity.onCloseSigner()
         }
     }
 }

--- a/ios/passkeys-webview-embedded/App.swift
+++ b/ios/passkeys-webview-embedded/App.swift
@@ -15,15 +15,6 @@ struct passkeys_webview_embeddedApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(safariViewManager)
-                .onOpenURL { url in
-                    handleIncomingURL(url)
-                }
-        }
-    }
-
-    private func handleIncomingURL(_ url: URL) {
-        if url.scheme == "passkeys" {
-            safariViewManager.isSafariViewVisible = false
         }
     }
 }

--- a/ios/passkeys-webview-embedded/ContentView.swift
+++ b/ios/passkeys-webview-embedded/ContentView.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
         let delegate = WebviewDelegate(openURLHandler: { url in
             self.urlToOpen = url
             self.safariViewManager.isSafariViewVisible = true
-        })
+        }, safariViewManager: safariViewManager)
 
         ZStack {
             Webview(url: URL(string: embeddedWalletUrl)!, uiDelegate: delegate)
@@ -66,9 +66,15 @@ struct SafariView: UIViewControllerRepresentable {
 
 class WebviewDelegate: NSObject, WKUIDelegate {
     private var openURLHandler: (URL) -> Void
+    private var safariViewManager: SafariViewManager
 
-    init(openURLHandler: @escaping (URL) -> Void) {
+    init(openURLHandler: @escaping (URL) -> Void, safariViewManager: SafariViewManager) {
         self.openURLHandler = openURLHandler
+        self.safariViewManager = safariViewManager
+    }
+
+    func closeSafariViewManager() -> Void {
+        safariViewManager.isSafariViewVisible = false
     }
 
     func webView(

--- a/ios/passkeys-webview-embedded/Environment.swift
+++ b/ios/passkeys-webview-embedded/Environment.swift
@@ -1,5 +1,5 @@
 import SwiftUI
 
 extension EnvironmentValues {
-    @Entry var embeddedWalletUrl: String = "https://dev.passkeys.foundation/playground?relay&returnTo=passkeys%3A%2F%2F%0A"
+    @Entry var embeddedWalletUrl: String = "https://dev.passkeys.foundation/playground?relay"
 }

--- a/ios/passkeys-webview-embedded/Info.plist
+++ b/ios/passkeys-webview-embedded/Info.plist
@@ -5,10 +5,6 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>passkeys</string>
-			</array>
 			<key>CFBundleURLName</key>
 			<string>passkey.network</string>
 		</dict>

--- a/ios/passkeys-webview-embedded/Webview.swift
+++ b/ios/passkeys-webview-embedded/Webview.swift
@@ -5,9 +5,27 @@ struct Webview: UIViewRepresentable {
     let url: URL
     let uiDelegate: WebviewDelegate
 
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
     func makeUIView(context: Context) -> WKWebView {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = WKWebsiteDataStore.default()
+
+        let contentController = WKUserContentController()
+        contentController.add(context.coordinator, name: "closeSigner")
+        configuration.userContentController = contentController
+
+        let js = """
+        if (!window.uiControl) {
+            window.uiControl = {};
+        }
+        window.uiControl.closeSigner = function() {
+            window.webkit.messageHandlers.closeSigner.postMessage(null);
+        };
+        """
+        contentController.addUserScript(WKUserScript(source: js, injectionTime: .atDocumentEnd, forMainFrameOnly: false))
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.uiDelegate = uiDelegate
@@ -17,4 +35,20 @@ struct Webview: UIViewRepresentable {
     }
 
     func updateUIView(_ webView: WKWebView, context: Context) {}
+
+    class Coordinator: NSObject, WKScriptMessageHandler {
+        var parent: Webview
+
+        init(_ parent: Webview) {
+            self.parent = parent
+        }
+
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            if message.name == "closeSigner" {
+                DispatchQueue.main.async {
+                    self.parent.uiDelegate.closeSafariViewManager()
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Didn't test Android yet, blind code, as I cannot run Android with the localhost passkeys atm (it crashes).

It seems that we will most likely need to instruct dapps to implement the onCloseSigner function, as there is no way (I found) to close the ChromeCustomTab from outside once it is open.

On top of that at best we can do is re-opening the main dapp activity with onCloseSigner (that the dapp needs to code/copy-paste from us) and at worst we will need the deep link since the main activity is paused while we are in ChromeCustomTab (whether we need the deep link depends on how the dapp handles main activity onPause in their app)

Depends on https://github.com/ExodusMovement/passkeys/pull/2691