### PR TITLE
feat: handle Android lifecycle events

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -56,7 +56,23 @@ class MainActivity : AppCompatActivity() {
 
         rootLayout.addView(connectButton)
     }
+
+    override fun onPause() {
+        super.onPause()
+        passkeys.onPause()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        passkeys.onResume()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        passkeys.onDestroy()
+    }
 }
+
 ```
 
 ## Publishing

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
 </manifest>

--- a/android/src/main/java/network/passkeys/client/Passkeys.kt
+++ b/android/src/main/java/network/passkeys/client/Passkeys.kt
@@ -19,6 +19,7 @@ class Passkeys @JvmOverloads constructor(
     defStyleAttr: Int = 0,
     private val initialUrl: String = "https://relay.passkeys.network"
 ) : WebView(context, attrs, defStyleAttr) {
+
     private var url: String = ""
     private var appId: String? = null
 
@@ -28,7 +29,10 @@ class Passkeys @JvmOverloads constructor(
         fun getInstance(): Passkeys? {
             return instance
         }
-        fun clearInstance() { instance = null }
+
+        fun clearInstance() {
+            instance = null
+        }
 
         private var customTabCallback: (() -> Unit)? = null
 
@@ -232,6 +236,14 @@ class Passkeys @JvmOverloads constructor(
                 completion(Result.failure(e))
             }
         }
+    }
+
+    fun onDestroy() {
+        loadUrl("about:blank")
+        clearInstance()
+        clearHistory()
+        removeAllViews()
+        destroy()
     }
 }
 

--- a/android/src/main/java/network/passkeys/client/Passkeys.kt
+++ b/android/src/main/java/network/passkeys/client/Passkeys.kt
@@ -23,8 +23,6 @@ class Passkeys @JvmOverloads constructor(
     private var appId: String? = null
 
     companion object {
-        const val CUSTOM_TAB_REQUEST_CODE = 100
-
         private var instance: Passkeys? = null
 
         fun getInstance(): Passkeys? {
@@ -166,7 +164,7 @@ class Passkeys @JvmOverloads constructor(
         }
 
         if (hasCustomTabsSupport(context)) {
-            activity.startActivityForResult(intent, CUSTOM_TAB_REQUEST_CODE)
+            activity.startActivity(intent)
         } else {
             // Fallback to opening the URL in the default browser
             val fallbackIntent = Intent(Intent.ACTION_VIEW, uri)

--- a/example/android/app/src/main/java/com/passkeysandroid/MainActivity.kt
+++ b/example/android/app/src/main/java/com/passkeysandroid/MainActivity.kt
@@ -1,13 +1,13 @@
-package com.passkeysandroid
+package com.passkeysandroid;
 
-import network.passkeys.client.Passkeys
+import network.passkeys.client.Passkeys;
 
-import android.app.PendingIntent
-import android.os.Bundle
-import android.view.View
-import android.widget.Button
-import android.widget.RelativeLayout
-import androidx.appcompat.app.AppCompatActivity
+import android.app.PendingIntent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.RelativeLayout;
+import androidx.appcompat.app.AppCompatActivity;
 
 class MainActivity : AppCompatActivity() {
     private lateinit var passkeys: Passkeys
@@ -47,5 +47,20 @@ class MainActivity : AppCompatActivity() {
         }
 
         rootLayout.addView(connectButton)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        passkeys.onPause()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        passkeys.onResume()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        passkeys.onDestroy()
     }
 }

--- a/react-native/android/src/main/java/passkeys/reactnative/PasskeysViewManager.kt
+++ b/react-native/android/src/main/java/passkeys/reactnative/PasskeysViewManager.kt
@@ -52,7 +52,6 @@ fun JSONArray.toWritableArray(): WritableArray {
     return writableArray
 }
 
-
 class PasskeysViewManager : SimpleViewManager<View>() {
 
     override fun getName() = "PasskeysView"
@@ -78,9 +77,17 @@ class PasskeysViewManager : SimpleViewManager<View>() {
 
     override fun onDropViewInstance(view: View) {
         super.onDropViewInstance(view)
-        if (view is Passkeys && Passkeys.getInstance() === view) {
-            Passkeys.clearInstance()
+        if (view is Passkeys) {
+            view.onDestroy()
         }
+    }
+
+    override fun onHostPause() {
+        Passkeys.getInstance()?.onPause()
+    }
+
+    override fun onHostResume() {
+        Passkeys.getInstance()?.onResume()
     }
 }
 
@@ -99,7 +106,7 @@ class PasskeysModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         }
 
         val passkeys = Passkeys.getInstance()
-        if (passkeys == null || activity?.isFinishing == true || passkeys?.isAttachedToWindow == false) {
+        if (passkeys == null || activity.isFinishing || !passkeys.isAttachedToWindow) {
             promise.reject("INVALID_VIEW", "Passkeys instance not initialized")
             return
         }


### PR DESCRIPTION
1. feat: handle Android lifecycle events
  - Addresses https://github.com/ExodusMovement/passkeys-mobile/pull/7#discussion_r1863095518
2. [fix: add permission for browser query](https://github.com/ExodusMovement/passkeys-mobile/commit/e77ec69787df76631ab465d8cc0737c265473559)

Closes: https://github.com/ExodusMovement/passkeys/issues/2973