### PR TITLE
feat: unify behaviour/errors across ios/android 

### DIFF
--- a/android/src/main/java/network/passkeys/client/Passkeys.kt
+++ b/android/src/main/java/network/passkeys/client/Passkeys.kt
@@ -142,7 +142,7 @@ class Passkeys @JvmOverloads constructor(
             window.nativeBridge.onLoadingEnd = function(loading, error) {
                 AndroidBridge.onLoadingEnd(loading, error ? String(error) : error);
             };
-            window.nativeBridge.onLoadingEnd(window.loading ? true : false, window.loadingError ? window.loadingError : null )
+            window.nativeBridge.onLoadingEnd(window.loading === false ? false : true, window.loadingError ? window.loadingError : null )
             window.nativeBridge.openSigner = function(url) {
                 if (typeof url !== 'string') throw new Error('url is not a string');
                 AndroidBridge.openSigner(url);

--- a/android/src/main/java/network/passkeys/client/Passkeys.kt
+++ b/android/src/main/java/network/passkeys/client/Passkeys.kt
@@ -200,6 +200,10 @@ class Passkeys @JvmOverloads constructor(
 
     fun openInCustomTab(url: String) {
         val uri = Uri.parse(url)
+        if (uri.scheme != "http" && uri.scheme != "https") {
+            println("Invalid url.")
+            return
+        }
         val customTabsIntent = CustomTabsIntent.Builder().build()
         val intent = customTabsIntent.intent
         intent.data = uri

--- a/android/src/main/java/network/passkeys/client/Passkeys.kt
+++ b/android/src/main/java/network/passkeys/client/Passkeys.kt
@@ -12,6 +12,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.cancel
 import org.json.JSONObject
 import java.util.UUID
 
@@ -82,6 +83,7 @@ class Passkeys @JvmOverloads constructor(
         if (instance === this) {
             clearInstance()
         }
+        coroutineScope.cancel()
     }
 
     private fun getActivity(context: android.content.Context): Activity? {
@@ -286,6 +288,7 @@ class Passkeys @JvmOverloads constructor(
     fun onDestroy() {
         loadUrl("about:blank")
         clearInstance()
+        stopLoading()
         clearHistory()
         removeAllViews()
         destroy()

--- a/android/src/main/java/network/passkeys/client/Passkeys.kt
+++ b/android/src/main/java/network/passkeys/client/Passkeys.kt
@@ -147,7 +147,7 @@ class Passkeys @JvmOverloads constructor(
                 AndroidBridge.resolveResult(id, result);
             };
             window.nativeBridge.onLoadingEnd = function(loading, error) {
-                AndroidBridge.onLoadingEnd(loading, error ? String(error) : error);
+                AndroidBridge.onLoadingEnd(loading, error ? String(error) : null);
             };
             window.nativeBridge.onLoadingEnd(window.loading === false ? false : true, window.loadingError ? window.loadingError : null )
             window.nativeBridge.openSigner = function(url) {

--- a/android/src/main/java/network/passkeys/client/Passkeys.kt
+++ b/android/src/main/java/network/passkeys/client/Passkeys.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.launch
 import org.json.JSONObject
 import java.util.UUID
 
+class Error(val msg: String) : Throwable(msg)
+
 class Passkeys @JvmOverloads constructor(
     context: android.content.Context,
     attrs: AttributeSet? = null,
@@ -175,7 +177,7 @@ class Passkeys @JvmOverloads constructor(
         try {
             val jsonObject = when {
                 result.isNullOrBlank() || result == "undefined" || result == "null" -> null
-                result == "\"no-method\"" -> throw IllegalStateException("Unsupported browser")
+                result == "\"no-method\"" -> throw Error("Unsupported browser")
                 else -> JSONObject(result)
             }
             deferredResults[id]?.complete(jsonObject)
@@ -196,7 +198,7 @@ class Passkeys @JvmOverloads constructor(
         val activity = getActivity(context)
 
         if (activity == null) {
-            throw IllegalStateException("No activity available to open the URL")
+            throw Error("No activity available to open the URL")
         }
 
         if (hasCustomTabsSupport(context)) {
@@ -250,7 +252,7 @@ class Passkeys @JvmOverloads constructor(
 
     fun callMethod(method: String, data: JSONObject?, completion: (Result<JSONObject?>) -> Unit) {
         if (appId == null) {
-            completion(Result.failure(IllegalArgumentException("appId cannot be null")))
+            completion(Result.failure(Error("appId cannot be null")))
             return
         }
         injectJavaScript()

--- a/android/src/main/java/network/passkeys/client/Passkeys.kt
+++ b/android/src/main/java/network/passkeys/client/Passkeys.kt
@@ -116,7 +116,12 @@ class Passkeys @JvmOverloads constructor(
             "AndroidBridge"
         )
 
-        webViewClient = object : WebViewClient() {}
+        webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                super.onPageFinished(view, url)
+                injectJavaScript()
+            }
+        }
     }
 
     private fun loadUrlWithBridge() {

--- a/android/src/main/java/network/passkeys/client/Passkeys.kt
+++ b/android/src/main/java/network/passkeys/client/Passkeys.kt
@@ -177,7 +177,7 @@ class Passkeys @JvmOverloads constructor(
         try {
             val jsonObject = when {
                 result.isNullOrBlank() || result == "undefined" || result == "null" -> null
-                result == "\"no-method\"" -> throw Error("Unsupported browser")
+                result == "\"no-method\"" -> throw Error("Method not defined")
                 else -> JSONObject(result)
             }
             deferredResults[id]?.complete(jsonObject)

--- a/ios/Sources/passkeys-mobile-ios/Passkeys.swift
+++ b/ios/Sources/passkeys-mobile-ios/Passkeys.swift
@@ -120,7 +120,14 @@ public struct Passkeys: View {
 
         let script = """
         if (!window.\(method)) return JSON.stringify({noMethod: true});
-        const result = window.\(method)(\(dataJSON));
+        let result;
+        try {
+            result = window.\(method)(\(dataJSON));
+        }
+        catch (error) {
+            return JSON.stringify({isError: true, error: error && (error.message || String(error))})
+        }
+
         if (result instanceof Promise) {
             return result
                 .then(resolved => JSON.stringify(resolved))

--- a/ios/Sources/passkeys-mobile-ios/Passkeys.swift
+++ b/ios/Sources/passkeys-mobile-ios/Passkeys.swift
@@ -12,8 +12,15 @@ public class WebViewModel: ObservableObject {
     public init() {}
 }
 
-public enum CustomError: Error {
+enum CustomError: Error, LocalizedError {
     case message(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .message(let msg):
+            return msg
+        }
+    }
 }
 
 public struct Passkeys: View {

--- a/ios/Sources/passkeys-mobile-ios/Passkeys.swift
+++ b/ios/Sources/passkeys-mobile-ios/Passkeys.swift
@@ -133,7 +133,12 @@ public struct Passkeys: View {
                 .then(resolved => JSON.stringify(resolved))
                 .catch(error => JSON.stringify({isError: true, error: error && (error.message || String(error))}));
         } else {
-            return JSON.stringify(result);
+            try {
+                return JSON.stringify(result);
+            }
+            catch (error) {
+                return JSON.stringify({isError: true, error: error && (error.message || String(error))});
+            }
         }
         """
         callAsyncJavaScript(script, completion: completion)

--- a/ios/Sources/passkeys-mobile-ios/Passkeys.swift
+++ b/ios/Sources/passkeys-mobile-ios/Passkeys.swift
@@ -85,7 +85,7 @@ public struct Passkeys: View {
                    let jsonData = jsResult.data(using: .utf8),
                    let jsonObject = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] {
                     if let noMethod = jsonObject["noMethod"] as? Bool, noMethod {
-                        completion(.failure(CustomError.message("Unsupported browser")))
+                        completion(.failure(CustomError.message("Method not defined")))
                     } else {
                         completion(.success(jsonObject))
                     }

--- a/ios/Sources/passkeys-mobile-ios/Passkeys.swift
+++ b/ios/Sources/passkeys-mobile-ios/Passkeys.swift
@@ -86,6 +86,12 @@ public struct Passkeys: View {
                    let jsonObject = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] {
                     if let noMethod = jsonObject["noMethod"] as? Bool, noMethod {
                         completion(.failure(CustomError.message("Method not defined")))
+                    } else if  let isError = jsonObject["isError"] as? Bool, isError {
+                        if let errorMessage = jsonObject["error"] as? String {
+                            completion(.failure(CustomError.message(errorMessage)))
+                        } else {
+                            completion(.failure(CustomError.message("Unknown JavaScript Error")))
+                        }
                     } else {
                         completion(.success(jsonObject))
                     }
@@ -118,7 +124,7 @@ public struct Passkeys: View {
         if (result instanceof Promise) {
             return result
                 .then(resolved => JSON.stringify(resolved))
-                .catch(error => { throw error; });
+                .catch(error => JSON.stringify({isError: true, error: error && (error.message || String(error))}));
         } else {
             return JSON.stringify(result);
         }

--- a/ios/Sources/passkeys-mobile-ios/Passkeys.swift
+++ b/ios/Sources/passkeys-mobile-ios/Passkeys.swift
@@ -218,9 +218,14 @@ class WebviewDelegate: NSObject, WKUIDelegate {
     }
 
     func openSafariView(url: String) {
-        guard let viewController = getPresentedViewController(),
-              let safariURL = URL(string: url) else {
-            print("Failed to retrieve presented view controller or invalid URL.")
+        guard let viewController = getPresentedViewController() else {
+            print("Failed to retrieve presented view controller.")
+            return
+        }
+        guard let safariURL = URL(string: url),
+              let scheme = safariURL.scheme,
+              ["http", "https"].contains(scheme.lowercased()) else {
+            print("Invalid URL.")
             return
         }
         presentSafariView(from: viewController, url: safariURL)

--- a/ios/Sources/passkeys-mobile-ios/Webview.swift
+++ b/ios/Sources/passkeys-mobile-ios/Webview.swift
@@ -33,7 +33,7 @@ struct Webview: UIViewRepresentable {
             window.webkit.messageHandlers.openSigner.postMessage(url);
         };
         window.nativeBridge.onLoadingEnd = function(loading, error) {
-            window.webkit.messageHandlers.onLoadingEnd.postMessage({ loading: loading, error: error && String(error) });
+            window.webkit.messageHandlers.onLoadingEnd.postMessage({ loading: loading, error: error ? String(error) : null });
         };
         """
         contentController.addUserScript(WKUserScript(source: js, injectionTime: .atDocumentStart, forMainFrameOnly: false))

--- a/react-native/ios/PasskeysViewManager.swift
+++ b/react-native/ios/PasskeysViewManager.swift
@@ -71,7 +71,7 @@ class PasskeysViewManager: RCTViewManager {
         let passkeysView = self.bridge.uiManager.view(forReactTag: reactTag) as? PasskeysView,
         let hostingController = passkeysView.hostingController
       else {
-        rejecter("INVALID_VIEW", "Did not find PasskeysView for the given tag.", nil)
+        rejecter("INVALID_VIEW", "Passkeys instance not initialized", nil)
         return
       }
 


### PR DESCRIPTION
Closes: https://github.com/ExodusMovement/passkeys/issues/2974

Checked/updated to be consistent:
1. window.loading not defined on relay :white_check_mark: 
1. relay loading throws an error & stores it in window.loadingError :white_check_mark: 
1. appId is null 🔴 
    - had to change behaviour to differ betwee ios/android to work around the appId not updating after initial iOS load (caused by workaround in cf123e67cb1e5dee4b121a9981f13ca09d1d7857). Library will still work fine. Will create a ticket to address. 
1. no-method is returned from execution script (e.g. when window.connect is not defined) :white_check_mark: 
    - need to add on iOS? Added :white_check_mark: 
1. no activity available :white_check_mark: 
    - iOS equivalent? unique for Android
1. INVALID_VIEW :white_check_mark: 
1. EXECUTION_ERROR :white_check_mark: 
1. openSigner url is not a string :white_check_mark: 
    - does it match between both? Should we throw? we now propagate the JS error & throw it to the caller
1. closeSigner call with data/undefined/null :white_check_mark: 
1. onLoadingEnd call with bad data - should it throw? :white_check_mark: 
1. callAsyncJavaScript :white_check_mark:
    - on Android need to add evaluateJavascript failure handling? handled :white_check_mark:
    -cancel deferredResult after X time? No, if JS code awaits forever, so should the native code :white_check_mark:
    -api call (e.g. window.connect) throws an error in sync code (e.g. JSON.stringify(result) throws) :white_check_mark:
    -api call (e.g. window.connect) throws an error in async code :white_check_mark:
    -result JSON.stringify(result) throws (for async/async) :white_check_mark:
    -any other errors iOS/Android can throw differently in callAsyncJavaScript? Nothing that wasn't handled in 8. :white_check_mark:
1. is null/undefined handled the same? No, undefined might be used as a string if passed in unexpected places, esp. on Android. But current usage is fine. :white_check_mark:
1. check for optional types & how they stringify. All good, but need to be careful :white_check_mark:
1. missing/invalid url :white_check_mark:
1. no webview instance :white_check_mark:
    - need to add on Android? Not needed
1. does JSON.stringify(result) return the same number of quotes for both? :white_check_mark:
1. missing data from getPresentedViewController :white_check_mark: 
    - should throw? Does it match Android? Should log like it does (iOS app crashes othewise), no need to match
1. Android & iOS Error: JSON Parse error: Unexpected identifier "object" after running connect that doesn't resolve. Maybe relay return value after timeout? :white_check_mark: was a relay bug https://github.com/ExodusMovement/passkeys/pull/3046
1. callMethod called with non-json data, e.g. null, undefined, non-object (esp. from RN)? null/json accepted, no other types allowed :white_check_mark:
1.  on Android firstLoad flickering. onDestroy issues? cannot repro, might have been fixed with some of the other items :white_check_mark: 