### PR TITLE
feat: (re)implement close signer on android

### DIFF
--- a/android/src/main/java/network/passkeys/client/Passkeys.kt
+++ b/android/src/main/java/network/passkeys/client/Passkeys.kt
@@ -49,12 +49,6 @@ class Passkeys @JvmOverloads constructor(
         fun clearInstance() {
             instance = null
         }
-
-        private var customTabCallback: (() -> Unit)? = null
-
-        fun setOnCloseSignerCallback(callback: () -> Unit) {
-            customTabCallback = callback
-        }
     }
 
     private val coroutineScope = MainScope()

--- a/android/src/main/java/network/passkeys/client/Passkeys.kt
+++ b/android/src/main/java/network/passkeys/client/Passkeys.kt
@@ -161,7 +161,14 @@ class Passkeys @JvmOverloads constructor(
     }
 
     private fun onCloseSigner() {
-        customTabCallback?.invoke()
+        val context = context
+        val activity = getActivity(context)
+
+        if (activity != null) {
+            val intent = Intent(context, activity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            context.startActivity(intent)
+        }
     }
 
     private fun onLoadingEnd(loading: Boolean, error: String?) {


### PR DESCRIPTION
Towards https://github.com/ExodusMovement/passkeys-signer/issues/740

In the case where the signer calls `window.close` we need to handle it on Android, since Android will not allow the Chrome Custom Tab to close in such cases. Re-implementing `onCloseSigner` to bring back our main activity into focus. Afaik there is no other way to programatically "close" the CCT. The alternative is the CCT deep links into our app, but that was rejected for DX reasons